### PR TITLE
Add ConnectionService timer

### DIFF
--- a/inapp-voice-android/app/src/main/java/com/vonage/inapp_voice_android/telecom/CallConnectionService.kt
+++ b/inapp-voice-android/app/src/main/java/com/vonage/inapp_voice_android/telecom/CallConnectionService.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import com.vonage.inapp_voice_android.App
 import com.vonage.inapp_voice_android.models.CallData
 import com.vonage.inapp_voice_android.utils.Constants
+import com.vonage.inapp_voice_android.utils.TimerManager
 import com.vonage.inapp_voice_android.utils.showToast
 
 /**
@@ -44,6 +45,7 @@ class CallConnectionService : ConnectionService() {
         connectionManagerPhoneAccount: PhoneAccountHandle?,
         request: ConnectionRequest?
     ): Connection {
+        TimerManager.cancelTimer(TimerManager.CONNECTION_SERVICE_TIMER)
         val bundle = request!!.extras
         val callId = bundle.getString(Constants.EXTRA_KEY_CALL_ID)!!
         val to = bundle.getString(Constants.EXTRA_KEY_TO)
@@ -68,6 +70,7 @@ class CallConnectionService : ConnectionService() {
     }
 
     override fun onCreateOutgoingConnectionFailed(connectionManagerPhoneAccount: PhoneAccountHandle?, request: ConnectionRequest?) {
+        TimerManager.cancelTimer(TimerManager.CONNECTION_SERVICE_TIMER)
         Log.e("onCreateOutgoingFailed:",request.toString())
         showToast(applicationContext, "onCreateOutgoingConnectionFailed")
     }

--- a/inapp-voice-android/app/src/main/java/com/vonage/inapp_voice_android/utils/TimerManager.kt
+++ b/inapp-voice-android/app/src/main/java/com/vonage/inapp_voice_android/utils/TimerManager.kt
@@ -1,0 +1,28 @@
+package com.vonage.inapp_voice_android.utils
+
+import android.os.Handler
+import android.os.Looper
+
+object TimerManager {
+    private val handler: Handler = Handler(Looper.getMainLooper())
+    private val timerMap: MutableMap<String, Runnable> = mutableMapOf()
+
+    const val CONNECTION_SERVICE_TIMER = "ConnectionServiceTimer"
+
+    fun startTimer(timerId: String, delayMillis: Long, callback: () -> Unit) {
+        val runnable = Runnable {
+            callback.invoke()
+            timerMap.remove(timerId)
+        }
+        timerMap[timerId] = runnable
+        handler.postDelayed(runnable, delayMillis)
+    }
+
+    fun cancelTimer(timerId: String) {
+        val runnable = timerMap[timerId]
+        if (runnable != null) {
+            handler.removeCallbacks(runnable)
+            timerMap.remove(timerId)
+        }
+    }
+}


### PR DESCRIPTION
Apparently, under some circumstances, Samsung devices don’t instantiate the `CallConnectionService` class, hence why the Call object was never being created (nor failure was being shown). 
It’s also a known bug on Samsung Devices which hasn’t been solved yet:
https://stackoverflow.com/questions/60098451/place-call-using-self-managed-connectionservice-not-working-on-samsung
https://forum.developer.samsung.com/t/self-managed-connectionservice-not-working/933/2

To workaround it, I'm setting a local timer of 500ms and, if the CallConnectionService doesn't get invoked in that interval, the call will be hung up also on the SDK.